### PR TITLE
Expose color selection event to support external live preview

### DIFF
--- a/src/ColorPickerWPF/ColorPickerControl.xaml.cs
+++ b/src/ColorPickerWPF/ColorPickerControl.xaml.cs
@@ -128,6 +128,7 @@ namespace ColorPickerWPF
             ColorDisplayBorder.Background = new SolidColorBrush(Color);
 
             IsSettingValues = false;
+            OnPickColor?.Invoke(color);
 
         }
 
@@ -176,7 +177,6 @@ namespace ColorPickerWPF
         private void Swatch_OnOnPickColor(Color color)
         {
             SetColor(color);
-            OnPickColor?.Invoke(color);
         }
 
         private void HSlider_OnOnValueChanged(double value)

--- a/src/ColorPickerWPF/ColorPickerWindow.xaml.cs
+++ b/src/ColorPickerWPF/ColorPickerWindow.xaml.cs
@@ -25,7 +25,7 @@ namespace ColorPickerWPF
         }
 
 
-        public static bool ShowDialog(out Color color, ColorPickerDialogOptions flags = ColorPickerDialogOptions.None, string customPaletteName = null)
+        public static bool ShowDialog(out Color color, ColorPickerDialogOptions flags = ColorPickerDialogOptions.None, string customPaletteName = null, ColorPickerControl.ColorPickerChangeHandler customPreviewEventHandler = null)
         {
             var instance = new ColorPickerWindow();
             color = instance.ColorPicker.Color;
@@ -46,6 +46,11 @@ namespace ColorPickerWPF
                 {
                     instance.ColorPicker.LoadDefaultCustomPalette();
                 }
+            }
+
+            if (customPreviewEventHandler != null)
+            {
+                instance.ColorPicker.OnPickColor += customPreviewEventHandler;
             }
             
             var result = instance.ShowDialog();


### PR DESCRIPTION
This change lets the consuming code subscribe to the `ColorPickerChangeHandler`-event from `ColorPickerControl` by adding an optional parameter to the `ColorPickerWindow.ShowDialog(...)` method. 

This lets the user add live previews of the selected color outside of the dedicated ColorPickerWPF window.